### PR TITLE
Make project balena-agnostic

### DIFF
--- a/urbit/Dockerfile
+++ b/urbit/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:latest
+COPY start-urbit.sh /usr/sbin/start-urbit.sh
+COPY get-urbit-code.sh /usr/sbin/get-urbit-code.sh
+COPY reset-urbit-code.sh /usr/sbin/reset-urbit-code.sh
+COPY run-urbit-cmd.sh /usr/sbin/run-urbit-cmd.sh
+RUN chmod +x /usr/sbin/start-urbit.sh && chmod +x /usr/sbin/get-urbit-code.sh && chmod +x /usr/sbin/reset-urbit-code.sh && chmod +x /usr/sbin/run-urbit-cmd.sh
+WORKDIR /urbit
+RUN mkdir piers && mkdir keys
+COPY keys/ keys/
+COPY piers/ piers/
+COPY install-urbit.sh /tmp/install-urbit.sh
+RUN echo "The Urbit's directory is populated with the following data:" && ls
+RUN  chmod +x /tmp/install-urbit.sh && /tmp/install-urbit.sh && rm /tmp/install-urbit.sh
+ENTRYPOINT ["/usr/sbin/start-urbit.sh"]

--- a/urbit/install-urbit.sh
+++ b/urbit/install-urbit.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-if [[ $BALENA_ARCH == "aarch64" ]]; then
+DEVICE_ARCH=$(uname -m)
+if [[ $DEVICE_ARCH == "aarch64" ]]; then
   curl https://s3.us-east-2.amazonaws.com/urbit-on-arm/urbit-on-arm_public.gpg | apt-key add -
   echo 'deb http://urbit-on-arm.s3-website.us-east-2.amazonaws.com buster custom' | tee /etc/apt/sources.list.d/urbit-on-arm.list
   dpkg --add-architecture arm64
   apt update
   apt install -y urbit:arm64 rsync
   rm -rf /var/lib/apt/lists/*
-elif [[ $BALENA_ARCH == "amd64" ]]; then
+elif [[ $DEVICE_ARCH == "x86_64" ]]; then
   mkdir binary && cd binary
   wget --content-disposition https://urbit.org/install/linux64/latest
   tar zxvf ./linux64.tgz --strip=1

--- a/urbit/start-urbit.sh
+++ b/urbit/start-urbit.sh
@@ -8,10 +8,10 @@ fi
 
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "Starting Urbit with Ames port: $AMES_PORT"
-
-if [[ $BALENA_ARCH == "aarch64" ]]; then
+DEVICE_ARCH=$(uname -m)
+if [[ $DEVICE_ARCH == "aarch64" ]]; then
     echo "Urbit binary:  $(which urbit)"
-elif [[ $BALENA_ARCH == "amd64" ]]; then
+elif [[ $DEVICE_ARCH == "x86_64" ]]; then
   export PATH="$PATH:/urbit/binary/urbit"
   echo "Urbit binary: $(which urbit)"
 fi


### PR DESCRIPTION
While we do use balena, we want this project to run on generic `docker-compose` infrastructure. 

For this reason, the x86 compatibility effort needed to move away from some balena features (such as Dockerfile.template) to implementing the same features without requiring balena. 

The end result is a slightly larger `urbit` container, since we use the generic Debian, rather the balena optimize one as the basis for `urbit`. The reason is that Debian supports multiple archs, so we can use the same base image and build for both x86 and aarch64. 

In the future, we should try to minimise the size of the 'urbit' image.
